### PR TITLE
Fix for lx_camera_node warnings during catkinmake/catkin build

### DIFF
--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/CMakeLists.txt
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/CMakeLists.txt
@@ -66,7 +66,7 @@ add_executable(${TARGET_NAME}
                 ${PROJECT_SOURCE_DIR}/src/lx_camera/lx_camera.cpp
                 ${PROJECT_SOURCE_DIR}/src/lx_camera/lx_camera_node.cpp)
 add_dependencies(${TARGET_NAME} ${catkin_EXPORTED_TARGETS} lx_camera_ros_gencpp)
-target_link_libraries(${TARGET_NAME} LxCameraApi ${OpenCV_LIBS} ${PCL_INCLUDE_DIRS} ${catkin_LIBRARIES})
+target_link_libraries(${TARGET_NAME} LxCameraApi ${OpenCV_LIBS} ${PCL_LIBRARIES} ${catkin_LIBRARIES})
 
 set(TARGET_NAME lx_localization_node)
 add_executable(${TARGET_NAME}


### PR DESCRIPTION
# Summary of Changes

Every catkinmake prints:
```
WARNING: Target "lx_camera_node" requests linking to directory "/usr/include/pcl-1.10".  Targets may link only to libraries.  CMake is dropping the item.
WARNING: Target "lx_camera_node" requests linking to directory "/usr/include/eigen3".  Targets may link only to libraries.  CMake is dropping the item.
WARNING: Target "lx_camera_node" requests linking to directory "/usr/include".  Targets may link only to libraries.  CMake is dropping the item.
WARNING: Target "lx_camera_node" requests linking to directory "/usr/include/vtk-7.1".  Targets may link only to libraries.  CMake is dropping the item.
WARNING: Target "lx_camera_node" requests linking to directory "/usr/include/freetype2".  Targets may link only to libraries.  CMake is dropping the item.
WARNING: Target "lx_camera_node" requests linking to directory "/usr/include/x86_64-linux-gnu".  Targets may link only to libraries.  CMake is dropping the item.
WARNING: Target "lx_camera_node" requests linking to directory "/usr/include/ni".  Targets may link only to libraries.  CMake is dropping the item.
WARNING: Target "lx_camera_node" requests linking to directory "/usr/include/openni2".  Targets may link only to libraries.  CMake is dropping the item.
```

## Link to Ticket
[ticket](https://app.clickup.com/t/86c4bxm23)



