### PR TITLE
Fix/tf_tree

### DIFF
--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_1_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_1_ros.launch
@@ -5,7 +5,7 @@
   <node name="cam1" pkg="lx_camera_ros" type="lx_camera_node" output="screen">
 	<!-- ip、日志路径、流配置、算法、工作模式配置、点云单位 -->
 	<param name="tof_frame_id" 					value="cam1_depth_frame"/>
-	<param name="rgb_frame_id" 					value="cam1_frame"/>
+	<param name="rgb_frame_id" 					value="cam1_rgb_frame"/>
 	<param name="intrinsic_depth_frame_id" 	    value="cam1_intrinsic_depth_frame"/>
 	<param name="intrinsic_rgb_frame_id" 	    value="cam1_intrinsic_rgb_frame"/>
 	<param name="main_frame_id" 	    		value="cam1_main_frame"/>

--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_1_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_1_ros.launch
@@ -10,7 +10,7 @@
 	<param name="intrinsic_rgb_frame_id" 	    value="cam1_intrinsic_rgb_frame"/>
 	<param name="main_frame_id" 	    		value="cam1_main_frame"/>
 	<param name="ip" 							value="192.168.2.21"/>
-	<param name="log_path" 						value="/var/log/"/>
+	<param name="log_path" 						value="/tmp/navflex/log/lx_camera/cam1/"/>
 	<param name="is_xyz" 						value="1" />
 	<param name="is_depth" 						value="1" />
 	<param name="is_amp" 						value="1" />

--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_2_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_2_ros.launch
@@ -5,7 +5,7 @@
   <node name="cam2" pkg="lx_camera_ros" type="lx_camera_node" output="screen">
 	<!-- ip、日志路径、流配置、算法、工作模式配置、点云单位 -->
 	<param name="tof_frame_id" 					value="cam2_depth_frame"/>
-	<param name="rgb_frame_id" 					value="cam2_frame"/>
+	<param name="rgb_frame_id" 					value="cam2_rgb_frame"/>
 	<param name="intrinsic_depth_frame_id" 	    value="cam2_intrinsic_depth_frame"/>
 	<param name="intrinsic_rgb_frame_id" 	    value="cam2_intrinsic_rgb_frame"/>
 	<param name="main_frame_id" 	    		value="cam2_main_frame"/>

--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_2_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_2_ros.launch
@@ -10,7 +10,7 @@
 	<param name="intrinsic_rgb_frame_id" 	    value="cam2_intrinsic_rgb_frame"/>
 	<param name="main_frame_id" 	    		value="cam2_main_frame"/>
 	<param name="ip" 							value="192.168.3.22"/>
-	<param name="log_path" 						value="/var/log/"/>
+	<param name="log_path" 						value="/tmp/navflex/log/lx_camera/cam2/"/>
 	<param name="is_xyz" 						value="1" />
 	<param name="is_depth" 						value="1" />
 	<param name="is_amp" 						value="1" />

--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_3_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_3_ros.launch
@@ -4,7 +4,7 @@
 
   <node name="cam3" pkg="lx_camera_ros" type="lx_camera_node" output="screen">
 	<!-- ip、日志路径、流配置、算法、工作模式配置、点云单位 -->
-	<param name="tof_frame_id" 					value="cam3_frame"/>
+	<param name="tof_frame_id" 					value="cam3_depth_frame"/>
 	<param name="rgb_frame_id" 					value="cam3_rgb_frame"/>
 	<param name="intrinsic_depth_frame_id" 	    value="cam3_intrinsic_depth_frame"/>
 	<param name="intrinsic_rgb_frame_id" 	    value="cam3_intrinsic_rgb_frame"/>

--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_3_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_3_ros.launch
@@ -10,7 +10,7 @@
 	<param name="intrinsic_rgb_frame_id" 	    value="cam3_intrinsic_rgb_frame"/>
 	<param name="main_frame_id" 	    		value="cam3_main_frame"/>
 	<param name="ip" 							value="192.168.0.23"/>
-	<param name="log_path" 						value="/var/log/"/>
+	<param name="log_path" 						value="/tmp/navflex/log/lx_camera/cam3/"/>
 	<param name="is_xyz" 						value="1" />
 	<param name="is_depth" 						value="1" />
 	<param name="is_amp" 						value="1" />


### PR DESCRIPTION
# Overview
This PR fixes circular dependency in the tf_tree while preserving naming scheme for the perception moduel.

# Changes
 - rename `tof_frame_id` to `camX_depth_frame`
 - rename `rgb_frame_id` to `camX_rgb_frame`
 - keep consistent naming across all cameras
 - update log paths

# Testing
Tested in Brighton (cb16, cb17) and Dayton without any noticable issues.