### PR TITLE
Fix: Update cam_info Topic Remapping

### DIFF
--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_1_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_1_ros.launch
@@ -57,7 +57,7 @@
 	<param name="lx_max_depth" 					value="8000" />
 	
         <remap from="/cam1/LxCamera_TofInfo" to="/cam1/transformedDepth/camera_info"/>
-        <remap from="/cam1/LxCamera_RgbInfo" to="/cam1/transformedColor/camera_info"/>
+        <remap from="/cam1/LxCamera_RgbInfo" to="/cam1/color/camera_info"/>
         <remap from="/cam1/LxCamera_Depth" to="/cam1/transformedDepth/image_raw"/>
         <remap from="/cam1/LxCamera_Rgb" to="/cam1/color/image_raw"/>
         <remap from="/cam1/LxCamera_Cloud" to="/perception/cam_left_pc"/>

--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_2_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_2_ros.launch
@@ -57,7 +57,7 @@
 	<param name="lx_max_depth" 					value="8000" />
 	
         <remap from="/cam2/LxCamera_TofInfo" to="/cam2/transformedDepth/camera_info"/>
-        <remap from="/cam2/LxCamera_RgbInfo" to="/cam2/transformedColor/camera_info"/>
+        <remap from="/cam2/LxCamera_RgbInfo" to="/cam2/color/camera_info"/>
         <remap from="/cam2/LxCamera_Depth" to="/cam2/transformedDepth/image_raw"/>
         <remap from="/cam2/LxCamera_Rgb" to="/cam2/color/image_raw"/>
         <remap from="/cam2/LxCamera_Cloud" to="/perception/cam_right_pc"/>

--- a/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_3_ros.launch
+++ b/linux/Sample/ros/lx_camera_node_ws/src/lx_camera_ros/launch/lx_camera_3_ros.launch
@@ -57,7 +57,7 @@
 	<param name="lx_max_depth" 					value="8000" />
 	
         <remap from="/cam3/LxCamera_TofInfo" to="/cam3/transformedDepth/camera_info"/>
-        <remap from="/cam3/LxCamera_RgbInfo" to="/cam3/transformedColor/camera_info"/>
+        <remap from="/cam3/LxCamera_RgbInfo" to="/cam3/color/camera_info"/>
         <remap from="/cam3/LxCamera_Depth" to="/cam3/transformedDepth/image_raw"/>
         <remap from="/cam3/LxCamera_Rgb" to="/cam3/color/image_raw"/>
         <remap from="/cam3/LxCamera_Cloud" to="/perception/cam_center_pc"/>


### PR DESCRIPTION
###### [ClickUp Ticket Link](https://app.clickup.com/t/86c6rahyh)

## Problem Statement
During initialization, the object detection node waits for a camera info message from cam3 to use for visualization purposes. This message is expected to come on the topic `/cam3/color/camera_info`.

Around milestone 1, the perception stack switch to using the `/cam{#}/color/image_raw` topics rather than `/cam{#}/transformedColor/image_raw`. As such, the LX camera data is mapped to this as well. However, the camera info messages are still mapped to `transformedColor` and provided on `color` via relay nodes. This should be swapped so that the relay nodes provide backwards compatibility, but the driver alone is sufficient to run the perception software.

## Change Log
- Update topic mapping

## Acceptance Criteria
- LX camera ROS driver provides camera info messages on `/cam{#}/color/camera_info` topic.

### Dev Testing
Tested in Dayton over 5 individual rows on 25.11.21.